### PR TITLE
Eliminate binary-string conversions

### DIFF
--- a/lib/proxy-server.js
+++ b/lib/proxy-server.js
@@ -48,7 +48,7 @@ ProxyServer.prototype.handleRequest = function(req, res) {
   log.withRequest(requestID).info('Received request to', req.url);
   var sendResponse = function (err, opts) {
     res.writeHead(opts[0], opts[1]);
-    res.end(opts[2]);
+    res.end(opts[2], 'binary');
   };
   parseRequestBody(req, function (err, body) {
     if (this.shuttingDown) {
@@ -75,11 +75,11 @@ ProxyServer.prototype.handleRequest = function(req, res) {
 module.exports = ProxyServer;
 
 function parseRequestBody(req, cb) {
-  var body = '';
-  req.setEncoding('utf8');
+  var buffers = [];
+  req.setEncoding('binary');
   req
-    .on('data', function(data) { body += data; })
-    .on('end', function() { cb(null, body); });
+    .on('data', function(data) { buffers.push(data); })
+    .on('end', function() { cb(null, Buffer.concat(buffers)); });
 }
 
 function handleUpstreamRequest(upstream, stats, requestID, opts, cb) {

--- a/lib/upstream.js
+++ b/lib/upstream.js
@@ -151,8 +151,6 @@ UpstreamRequest.prototype.recordTimingStats = function (response) {
   this.parent.statsdClient.timing('responseTime', response.responseTime);
 };
 
-var util = require('util');
-
 UpstreamRequest.prototype.send = function(cb) {
   if (++this.attempts > this.attemptLimit) {
     return cb(new Error("Too many retries"), { attempts: this.attempts }, null);

--- a/lib/upstream.js
+++ b/lib/upstream.js
@@ -151,20 +151,30 @@ UpstreamRequest.prototype.recordTimingStats = function (response) {
   this.parent.statsdClient.timing('responseTime', response.responseTime);
 };
 
+var util = require('util');
+
 UpstreamRequest.prototype.send = function(cb) {
   if (++this.attempts > this.attemptLimit) {
     return cb(new Error("Too many retries"), { attempts: this.attempts }, null);
   }
   var req = this.parent.httpModule.request(this.options, function (response) {
-    var upstreamBody = '';
-    response.setEncoding('utf8');
-    response.on('data', function (data) { upstreamBody += data; })
+    var upstreamBodyChunkBuffers = [];
+    response.setEncoding('binary');
+    response
+      .on('data', function (data) {
+        if (!(data instanceof Buffer)) {
+          data = new Buffer(data, "binary");
+        }
+        upstreamBodyChunkBuffers.push(data);
+      })
       .on('end', function () {
         response.responseTime = measureElapsedTime(this.startTime);
         response.waitTime = this.socketWait;
         response.attempts = this.attempts;
         this.recordTimingStats(response);
-        if (!this.timedOut) { cb(null, response, upstreamBody); }
+        if (!this.timedOut) {
+          cb(null, response, Buffer.concat(upstreamBodyChunkBuffers));
+        }
       }.bind(this));
   }.bind(this));
   if (this.getTimeout() > 0) {

--- a/test/upstream.js
+++ b/test/upstream.js
@@ -1,6 +1,5 @@
 var inspect = require('util').inspect;
 var url = require('url');
-var childProcess = require('child_process');
 var assert = require('chai').assert;
 var Upstream = require('../lib/upstream');
 var testServer = require('./helpers/testserver');
@@ -34,6 +33,7 @@ describe('Upstream', function () {
         upstream.request(opts, function (err, resp, body) {
           if (err) { return done(err); }
 
+          body = body.toString();
           assert.notInclude(body, 'user-agent => Abc123');
           assert.include(body, 'user-agent => Mallorca');
           done();
@@ -52,6 +52,7 @@ describe('Upstream', function () {
         upstream.request(opts, function (err, resp, body) {
           if (err) { return done(err); }
 
+          body = body.toString();
           assert.notInclude(body, 'host => testserver');
           assert.include(body, 'host => localhost');
           done();
@@ -68,6 +69,7 @@ describe('Upstream', function () {
         };
 
         upstream.request(opts, function (err, resp, body) {
+          body = body.toString();
           assert.notOk(err);
           assert.include(body, REQ_BODY);
           done();
@@ -96,6 +98,7 @@ describe('Upstream', function () {
       upstream.request(opts, function (err, resp, body) {
         if (err) { return done(err); }
 
+        body = body.toString();
         assert.include(body, 'user-agent => testAgent');
         done();
       });


### PR DESCRIPTION
This branch ensures that we treat all the all request/response body content as raw binary buffers, instead of treating them as strings. This eliminates the range of Unicode encoding/decoding problems that we could run into, not to mention that it was completely unnecessary.
